### PR TITLE
Docstring and test fixes

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -23,7 +23,7 @@ but is more general because the vectors can be any type.
 julia> ndgrid_array(1:3, 1:2)
 ([1 1; 2 2; 3 3], [1 2; 1 2; 1 2])
 
-julia> ndgrid(1:3, [:a,:b])
+julia> ndgrid_array(1:3, [:a,:b])
 ([1 1; 2 2; 3 3], [:a :b; :a :b; :a :b])
 ```
 """

--- a/src/ndgrid-oneto.jl
+++ b/src/ndgrid-oneto.jl
@@ -7,7 +7,7 @@ export ndgrid
 
 
 """
-    GridOT{T,d,D} <: AbstractArray{T,D}
+    GridOT{T,d,D} <: AbstractGrid{T,d,D}
 The `d`th component of `D`-dimensional `ndgrid(1:M, 1:N, ...)`
 where `1 ≤ d ≤ D`.
 """

--- a/src/ndgrid-step-range-len.jl
+++ b/src/ndgrid-step-range-len.jl
@@ -18,8 +18,9 @@ struct GridSL{T,d,D, R, S} <: AbstractGrid{T,d,D}
 
     function GridSL(dims::Dims{D}, v::StepRangeLen{T,R,S}, d::Int) where {D, T, R, S}
         1 ≤ d ≤ D || throw(ArgumentError("$d for $dims"))
-#       eltype(v.len) == Int || throw("non-Int v.len unsupported")
-#       eltype(v.offset) == Int || throw("non-Int v.offset unsupported")
+# a robot says the following two lines are superfluous:
+        eltype(v.len) == Int || throw("non-Int v.len unsupported")
+        eltype(v.offset) == Int || throw("non-Int v.offset unsupported")
         new{T,d,D,R,S}(dims, v.ref, v.step, v.len, v.offset)
     end
 end

--- a/src/ndgrid-step-range-len.jl
+++ b/src/ndgrid-step-range-len.jl
@@ -18,8 +18,8 @@ struct GridSL{T,d,D, R, S} <: AbstractGrid{T,d,D}
 
     function GridSL(dims::Dims{D}, v::StepRangeLen{T,R,S}, d::Int) where {D, T, R, S}
         1 ≤ d ≤ D || throw(ArgumentError("$d for $dims"))
-        eltype(v.len) == Int || throw("non-Int v.len unsupported")
-        eltype(v.offset) == Int || throw("non-Int v.offset unsupported")
+#       eltype(v.len) == Int || throw("non-Int v.len unsupported")
+#       eltype(v.offset) == Int || throw("non-Int v.offset unsupported")
         new{T,d,D,R,S}(dims, v.ref, v.step, v.len, v.offset)
     end
 end

--- a/test/ndgrid-avect.jl
+++ b/test/ndgrid-avect.jl
@@ -1,6 +1,6 @@
 # ndgrid-avect.jl test AbstractVector types
 
-using LazyGrids: ndgrid, ndgrid_array, GridAV, GridUR
+using LazyGrids: ndgrid, ndgrid_array, GridAV, GridUR, GridSL
 using Test: @test, @testset, @test_throws, @inferred
 
 @testset "avect" begin


### PR DESCRIPTION
My first foray into robot-assisted code review.
The changes in this PR were suggested by gemini cli 0.39.0 and verified by me.

Robot also suggests removing these two supposedly superfluous lines:
https://github.com/JuliaArrays/LazyGrids.jl/blob/fc0daf23129bfe33a308629b17be2339af296e01/src/ndgrid-step-range-len.jl#L21

but I find the constructors for `StepRangeLen` to be confusing enough to be unsure:
https://github.com/JuliaLang/julia/blob/ae6562cdd6f1d9ba1571688f84197dd4baa1c530/base/range.jl#L515
so I retain the two lines for now.

Robot also recommended changes near:
https://github.com/JuliaArrays/LazyGrids.jl/blob/fc0daf23129bfe33a308629b17be2339af296e01/src/ndgrid-avect.jl#L37
```julia
37 - _grid(d::Int, dims::Dims, v::UnitRange)      = GridUR(dims, v, d)
37 + _grid(d::Int, dims::Dims, v::UnitRange{Int}) = GridUR(dims, v, d)
43 - _grid_type(d::Int, D::Int, ::UnitRange{T})      where T = GridUR{T, d, D}
43 + _grid_type(d::Int, D::Int, ::UnitRange{Int})            = GridUR{Int, d, D}
```
but I was unsure of the benefits of that `Int` specialization.

Nothing breaking here, so no version bump.