### PR TITLE
Add support for `BigInt` ranges

### DIFF
--- a/src/ndgrid-avect.jl
+++ b/src/ndgrid-avect.jl
@@ -59,13 +59,13 @@ julia> xg, yg = ndgrid(1:3, [:a, :b])
 ([1 1; 2 2; 3 3], [:a :b; :a :b; :a :b])
 
 julia> xg
-3×2 LazyGrids.GridUR{Int64, 1, 2}:
+3×2 LazyGrids.GridUR{Int64, 1, 2, Tuple{Int64, Int64}}:
  1  1
  2  2
  3  3
 
 julia> yg
-3×2 LazyGrids.GridAV{Symbol, 2, 2, Vector{Symbol}}:
+3×2 LazyGrids.GridAV{Symbol, 2, 2, Vector{Symbol}, Tuple{Int64, Int64}}:
  :a  :b
  :a  :b
  :a  :b

--- a/src/ndgrid-avect.jl
+++ b/src/ndgrid-avect.jl
@@ -11,13 +11,13 @@ export ndgrid
 The `d`th component of `D`-dimensional `ndgrid(v₁, v₂, ...)`
 where `1 ≤ d ≤ D` and `v_d` is an `AbstractVector`.
 """
-struct GridAV{T,d,D,V <: AbstractVector{T}} <: AbstractGrid{T,d,D}
-    dims::Dims{D}
+struct GridAV{T, d, D, V <: AbstractVector{T}, SZ <: NTuple{D,Integer}} <: AbstractGrid{T,d,D}
+    dims::SZ
     v::V
 
-    function GridAV(dims::Dims{D}, v::V, d::Int) where {D, T, V <: AbstractVector{T}}
+    function GridAV(dims::SZ, v::V, d::Int) where {D, T, V <: AbstractVector{T}, SZ <: NTuple{D,Integer}}
         1 ≤ d ≤ D || throw(ArgumentError("$d for $dims"))
-        new{T,d,D,V}(dims, v)
+        new{T,d,D,V,SZ}(dims, v)
     end
 end
 
@@ -33,17 +33,17 @@ end
 end
 
 
-_grid(d::Int, dims::Dims, v::Base.OneTo{T}) where T = GridOT(T, dims, d)
-_grid(d::Int, dims::Dims, v::UnitRange)      = GridUR(dims, v, d)
-_grid(d::Int, dims::Dims, v::StepRangeLen)   = GridSL(dims, v, d)
-_grid(d::Int, dims::Dims, v::AbstractRange)  = GridAR(dims, v, d)
-_grid(d::Int, dims::Dims, v::AbstractVector) = GridAV(dims, v, d)
+_grid(d::Int, dims::NTuple{D,Integer}, v::Base.OneTo{T})  where {D,T} = GridOT(T, dims, d)
+_grid(d::Int, dims::NTuple{D,Integer}, v::UnitRange)      where D = GridUR(dims, v, d)
+_grid(d::Int, dims::NTuple{D,Integer}, v::StepRangeLen)   where D = GridSL(dims, v, d)
+_grid(d::Int, dims::NTuple{D,Integer}, v::AbstractRange)  where D = GridAR(dims, v, d)
+_grid(d::Int, dims::NTuple{D,Integer}, v::AbstractVector) where D = GridAV(dims, v, d)
 
-_grid_type(d::Int, D::Int, ::Base.OneTo{T})     where T = GridOT{T, d, D}
-_grid_type(d::Int, D::Int, ::UnitRange{T})      where T = GridUR{T, d, D}
-_grid_type(d::Int, D::Int, ::StepRangeLen{T,R,S}) where {T,R,S} = GridSL{T, d, D, R, S}
-_grid_type(d::Int, D::Int, v::AbstractRange{T})  where T = GridAR{T, d, D, typeof(step(v))}
-_grid_type(d::Int, D::Int, ::V) where {T, V <: AbstractVector{T}} = GridAV{T, d, D, V}
+_grid_type(d::Int, D::Int, ::Base.OneTo{T}, sz::Type{SZ}) where {T, SZ} = GridOT{T, d, D, SZ}
+_grid_type(d::Int, D::Int, ::UnitRange{T}, sz::Type{SZ})  where {T, SZ} = GridUR{T, d, D, SZ}
+_grid_type(d::Int, D::Int, ::StepRangeLen{T,R,S}, sz::Type{SZ}) where {T, R, S, SZ} = GridSL{T, d, D, R, S, SZ}
+_grid_type(d::Int, D::Int, v::AbstractRange{T}, sz::Type{SZ}) where {T, SZ} = GridAR{T, d, D, typeof(step(v)), SZ}
+_grid_type(d::Int, D::Int, ::V, sz::Type{SZ}) where {T, V <: AbstractVector{T}, SZ} = GridAV{T, d, D, V, SZ}
 
 
 """
@@ -74,6 +74,7 @@ julia> yg
 function ndgrid(vs::Vararg{AbstractVector})
     D = length(vs)
     dims = ntuple(d -> length(vs[d]), D)
-    T = Tuple{ntuple(d -> _grid_type(d, D, vs[d]), D)...} # return type
+    SZ = typeof(dims)
+    T = Tuple{ntuple(d -> _grid_type(d, D, vs[d], SZ), D)...} # return type
     return ntuple(d -> _grid(d, dims, vs[d]), D)::T
 end

--- a/src/ndgrid-oneto.jl
+++ b/src/ndgrid-oneto.jl
@@ -11,12 +11,12 @@ export ndgrid
 The `d`th component of `D`-dimensional `ndgrid(1:M, 1:N, ...)`
 where `1 ≤ d ≤ D`.
 """
-struct GridOT{T,d,D} <: AbstractGrid{T,d,D}
-    dims::Dims{D}
+struct GridOT{T, d, D, SZ <: NTuple{D,Integer}} <: AbstractGrid{T,d,D}
+    dims::SZ
 
-    function GridOT(T::Type{<:Integer}, dims::Dims{D}, d::Int) where D
+    function GridOT(T::Type{<:Integer}, dims::SZ, d::Int) where {D, SZ<:NTuple{D,Integer}}
         1 ≤ d ≤ D || throw(ArgumentError("$d for $dims"))
-        new{T,d,D}(dims)
+        new{T,d,D,SZ}(dims)
     end
 end
 

--- a/src/ndgrid-range.jl
+++ b/src/ndgrid-range.jl
@@ -5,19 +5,19 @@ ndgrid type for an AbstractRange input.
 
 
 """
-    GridAR{T,d,D,S} <: AbstractGrid{T,d,D}
+    GridAR{T,d,D,S,SZ} <: AbstractGrid{T,d,D}
 The `d`th component of `D`-dimensional `ndgrid(v₁, v₂, ...)`
 where `1 ≤ d ≤ D` and `v_d` is an `AbstractRange`.
 """
-struct GridAR{T,d,D,S} <: AbstractGrid{T,d,D}
-    dims::Dims{D}
+struct GridAR{T, d, D, S, SZ <: NTuple{D,Integer}} <: AbstractGrid{T,d,D}
+    dims::SZ
     first0::T # first - step
     step::S
 
-    function GridAR(dims::Dims{D}, v::AbstractRange{T}, d::Int) where {D, T}
+    function GridAR(dims::SZ, v::AbstractRange{T}, d::Int) where {D, T, SZ <: NTuple{D,Integer}}
         1 ≤ d ≤ D || throw(ArgumentError("$d for $dims"))
         S = typeof(step(v))
-        new{T,d,D,S}(dims, first(v) - step(v), step(v))
+        new{T,d,D,S,SZ}(dims, first(v) - step(v), step(v))
     end
 end
 

--- a/src/ndgrid-step-range-len.jl
+++ b/src/ndgrid-step-range-len.jl
@@ -5,23 +5,23 @@ ndgrid type for an StepRangeLen input.
 
 
 """
-    GridSL{T,d,D} <: AbstractGrid{T,d,D}
+    GridSL{T,d,D,R,S,SZ} <: AbstractGrid{T,d,D}
 The `d`th component of `D`-dimensional `ndgrid(v₁, v₂, ...)`
 where `1 ≤ d ≤ D` and `v_d` is a `StepRangeLen`.
 """
-struct GridSL{T,d,D, R, S} <: AbstractGrid{T,d,D}
-    dims::Dims{D}
+struct GridSL{T, d, D, R, S, SZ <: NTuple{D,Integer}} <: AbstractGrid{T,d,D}
+    dims::SZ
     ref::R
     step::S
     len::Int
     offset::Int
 
-    function GridSL(dims::Dims{D}, v::StepRangeLen{T,R,S}, d::Int) where {D, T, R, S}
+    function GridSL(dims::SZ, v::StepRangeLen{T,R,S}, d::Int) where {D, T, R, S, SZ <: NTuple{D,Integer}}
         1 ≤ d ≤ D || throw(ArgumentError("$d for $dims"))
 # a robot says the following two lines are superfluous:
         eltype(v.len) == Int || throw("non-Int v.len unsupported")
         eltype(v.offset) == Int || throw("non-Int v.offset unsupported")
-        new{T,d,D,R,S}(dims, v.ref, v.step, v.len, v.offset)
+        new{T,d,D,R,S,SZ}(dims, v.ref, v.step, v.len, v.offset)
     end
 end
 

--- a/src/ndgrid-unitr.jl
+++ b/src/ndgrid-unitr.jl
@@ -5,26 +5,26 @@ ndgrid type a "UnitRange{Int}" input
 
 
 """
-    GridUR{T,d,D} <: AbstractGrid{T,d,D}
+    GridUR{T, d, Da, SZ} <: AbstractGrid{T,d,D}
 The `d`th component of `D`-dimensional `ndgrid(a:b, c:d, ...)`
 where `1 ≤ d ≤ D`.
 """
-struct GridUR{T,d,D} <: AbstractGrid{T,d,D}
-    dims::Dims{D}
+struct GridUR{T, d, D, SZ <: NTuple{D,Integer}} <: AbstractGrid{T,d,D}
+    dims::SZ
     first0::T # first-1
 
-    function GridUR(dims::Dims{D}, v::AbstractRange{T}, d::Int) where {T,D}
+    function GridUR(dims::SZ, v::AbstractRange{T}, d::Int) where {T, D, SZ <: NTuple{D,Integer}}
         1 ≤ d ≤ D || throw(ArgumentError("$d for $dims"))
-        T == Int || throw(ArgumentError("only Int supported"))
-        new{T,d,D}(dims, first(v) - one(T))
+        T <: Integer || throw(ArgumentError("only Integer supported"))
+        new{T,d,D,SZ}(dims, first(v) - one(T))
     end
 end
 
 
 @inline Base.@propagate_inbounds function Base.getindex(
     a::GridUR{T,d,D},
-    i::Vararg{Int,D},
-) where {T <: Int, d, D}
+    i::Vararg{Integer,D},
+) where {T <: Integer, d, D}
     @boundscheck checkbounds(a, i...)
 #   @boundscheck checkbounds(i, d)
     return a.first0 + @inbounds i[d] # i don't want to deal with one(T) here

--- a/test/ndgrid-range.jl
+++ b/test/ndgrid-range.jl
@@ -4,6 +4,21 @@ using LazyGrids: ndgrid, ndgrid_array, GridAR, GridSL, GridUR
 using Test: @test, @testset, @test_throws, @inferred
 
 
+@testset "StepRange BigInt" begin
+    x = BigInt(1):Int8(2):BigInt(9) # StepRange
+    y = BigInt(1):BigInt(7) # UnitRange
+    xx, yy = @inferred ndgrid(x, y)
+    @test eltype(xx) === eltype(x)
+    @test eltype(yy) === eltype(y)
+    @test size(xx) == (length(x), length(y))
+    @test size(yy) == (length(x), length(y))
+    @test xx isa GridAR
+    @test yy isa GridUR
+    @test xx[:,1] == x
+    @test yy[1,:] == y
+end
+
+
 @testset "cvect" begin
     x = 'a':9:'z' # character range
     y = 1:2


### PR DESCRIPTION
Addresses #37 

`Dims` is hardwired to a type of `Int` which is too restrictive for `BigInt` ranges,
so this PR replaces `Dims` with `NTuple{D,Integer}`

It is unknown whether this generalization would slow things down, so I might not merge until someone actually requests this change.