### PR TITLE
exclude test/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      - "test/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,4 @@ updates:
       interval: "weekly"
     exclude-paths:
       - "test/*"
+      - "docs/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,30 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "julia"
     directory: "/"
     schedule:
       interval: "weekly"
-    exclude-paths:
-      - "test/*"
-      - "docs/*"
+    groups:
+      all-julia-packages:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/docs"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: "julia"
+    directory: "/test"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
hopefully avoids a multitude of useless PRs by dependabot for `test/Project.toml`

latest try based on this:
https://discourse.julialang.org/t/psa-github-dependabot-now-supports-julia/134997/16?u=eben60